### PR TITLE
Adding new driverkit for amazonlinux2_5.4.219-126.411.amzn2.x86_64_1

### DIFF
--- a/driverkit/config/2.0.0+driver/amazonlinux2_5.4.219-126.411.amzn2.x86_64_1.yaml
+++ b/driverkit/config/2.0.0+driver/amazonlinux2_5.4.219-126.411.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.219-126.411.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/2.0.0+driver/x86_64/falco_amazonlinux2_5.4.219-126.411.amzn2.x86_64_1.ko

--- a/driverkit/config/3.0.1+driver/x86_64/amazonlinux2_5.4.219-126.411.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3.0.1+driver/x86_64/amazonlinux2_5.4.219-126.411.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.219-126.411.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3.0.1+driver/x86_64/falco_amazonlinux2_5.4.219-126.411.amzn2.x86_64_1.ko

--- a/driverkit/config/39ae7d40496793cf3d3e7890c9bbdc202263836b/amazonlinux2_5.4.219-126.411.amzn2.x86_64_1.yaml
+++ b/driverkit/config/39ae7d40496793cf3d3e7890c9bbdc202263836b/amazonlinux2_5.4.219-126.411.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.219-126.411.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/39ae7d40496793cf3d3e7890c9bbdc202263836b/falco_amazonlinux2_5.4.219-126.411.amzn2.x86_64_1.ko


### PR DESCRIPTION
Adding new driverkit for amazonlinux2. This is related to https://github.com/falcosecurity/test-infra/pull/654 